### PR TITLE
Fix soft-delete and history modes

### DIFF
--- a/internal/connector/mapping.go
+++ b/internal/connector/mapping.go
@@ -95,7 +95,7 @@ var typeMappings = []typeMapping{
 		surrealType: func(v string) (interface{}, error) {
 			m := map[string]interface{}{}
 			if err := json.Unmarshal([]byte(v), &m); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("surrealType(object): %w", err)
 			}
 			return m, nil
 		},

--- a/internal/connector/server.go
+++ b/internal/connector/server.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 

--- a/internal/connector/server.go
+++ b/internal/connector/server.go
@@ -353,12 +353,16 @@ func (s *Server) AlterTable(ctx context.Context, req *pb.AlterTableRequest) (*pb
 // Truncate implements the Truncate method required by the DestinationConnectorServer interface
 func (s *Server) Truncate(ctx context.Context, req *pb.TruncateRequest) (*pb.TruncateResponse, error) {
 	if s.debugging() {
-		s.logDebug("Truncate called", "schema", req.SchemaName, "table", req.TableName)
-		// SyncedColumn is e.g. `_sivetran_synced` which is timestamp-like column/field
-		s.logDebug("SyncedColumn", "column", req.SyncedColumn)
+		s.logDebug("Truncate called",
+			"schema", req.SchemaName,
+			"table", req.TableName,
+			// SyncedColumn is e.g. `_sivetran_synced` which is timestamp-like column/field
+			"syncedColumn", req.SyncedColumn,
+		)
 		if req.Soft != nil {
-			// DeletedColumn is e.g. `_sivetran_deleted` which is bool-like column/field
-			s.logDebug("Soft.DeletedColumn", "column", req.Soft.DeletedColumn)
+			s.logDebug("This is a soft truncation. See https://github.com/fivetran/fivetran_partner_sdk/blob/main/development-guide.md#truncate",
+				"soft.deletedColumn", req.Soft.DeletedColumn,
+			)
 		}
 		if req.UtcDeleteBefore != nil {
 			s.logDebug("UtcDeleteBefore", "time", req.UtcDeleteBefore.AsTime().Format(time.RFC3339))
@@ -368,12 +372,75 @@ func (s *Server) Truncate(ctx context.Context, req *pb.TruncateRequest) (*pb.Tru
 		//   SOFT DELETE:  `UPDATE <table> SET _fivetran_deleted = true WHERE _fivetran_synced <= <UtcDeleteBefore>`
 		//   HARD DELETE:  `DELETE FROM <table> WHERE _fivetran_synced <= <UtcDeleteBefore>`
 	}
+	cfg, err := s.parseConfig(req.Configuration)
+	if err != nil {
+		return &pb.TruncateResponse{
+			Response: &pb.TruncateResponse_Warning{
+				Warning: &pb.Warning{
+					Message: err.Error(),
+				},
+			},
+		}, err
+	}
+
+	db, err := s.connect(cfg, req.SchemaName)
+	if err != nil {
+		return &pb.TruncateResponse{
+			Response: &pb.TruncateResponse_Warning{
+				Warning: &pb.Warning{
+					Message: err.Error(),
+				},
+			},
+		}, err
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			s.logWarning("failed to close db", err)
+		}
+	}()
+
+	if req.Soft != nil {
+		// DeletedColumn is e.g. `_sivetran_deleted` which is bool-like column/field
+		s.logInfo("Doing a soft truncation",
+			"soft.deletedColumn", req.Soft.DeletedColumn,
+		)
+
+		if err := s.softTruncate(db, req); err != nil {
+			return &pb.TruncateResponse{
+				Response: &pb.TruncateResponse_Warning{
+					Warning: &pb.Warning{
+						Message: err.Error(),
+					},
+				},
+			}, err
+		}
+	}
 
 	return &pb.TruncateResponse{
 		Response: &pb.TruncateResponse_Success{
 			Success: true,
 		},
 	}, nil
+}
+
+func (s *Server) softTruncate(db *surrealdb.DB, req *pb.TruncateRequest) error {
+	deletedColumn := req.Soft.DeletedColumn
+
+	res, err := surrealdb.Query[any](db, "UPDATE type::table($tb) SET "+deletedColumn+" = true WHERE type::field($sc) <= type::datetime($utc)", map[string]interface{}{
+		"tb":  req.TableName,
+		"dc":  deletedColumn,
+		"sc":  req.SyncedColumn,
+		"utc": req.UtcDeleteBefore.AsTime().Format(time.RFC3339),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to soft truncate: %w", err)
+	}
+
+	if s.debugging() {
+		s.logDebug("SoftTruncate result", "result", res)
+	}
+
+	return nil
 }
 
 // WriteBatch implements the WriteBatch method required by the DestinationConnectorServer interface

--- a/internal/connector/table_read.go
+++ b/internal/connector/table_read.go
@@ -142,6 +142,8 @@ func (s *Server) columnsFromSurrealToFivetran(sColumns []columnInfo) ([]*pb.Colu
 			pbDataType = pb.DataType_BOOLEAN
 		case "datetime":
 			pbDataType = pb.DataType_UTC_DATETIME
+		case "object":
+			pbDataType = pb.DataType_JSON
 		default:
 			return nil, fmt.Errorf("columnsFromSurrealToFivetran: unsupported data type: %s", c.Type)
 		}

--- a/internal/connector/table_read.go
+++ b/internal/connector/table_read.go
@@ -135,8 +135,6 @@ func (s *Server) columnsFromSurrealToFivetran(sColumns []columnInfo) ([]*pb.Colu
 		case "int":
 			pbDataType = pb.DataType_INT
 		case "float":
-			pbDataType = pb.DataType_FLOAT
-		case "double":
 			pbDataType = pb.DataType_DOUBLE
 		case "bool":
 			pbDataType = pb.DataType_BOOLEAN

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		logger.Error().Err(err).Msg("failed to listen")
+		os.Exit(1)
 	}
 
 	// Create a new gRPC server with increased message size limits

--- a/tests/db-validator/types.go
+++ b/tests/db-validator/types.go
@@ -24,12 +24,32 @@ func (sv *SurrealValue) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if m, ok := raw.(map[string]interface{}); ok {
 		// Check for RecordID type
 		if table, ok := m["table"].(string); ok {
-			if id, ok := m["id"].(string); ok {
+			switch id := m["id"].(type) {
+			case string:
 				sv.Value = models.RecordID{
 					Table: table,
 					ID:    id,
 				}
 				return nil
+			case []any:
+				sv.Value = models.RecordID{
+					Table: table,
+					ID:    id,
+				}
+				return nil
+			default:
+				return fmt.Errorf("invalid id type: %T", id)
+			}
+		}
+
+		if intlike, ok := m["uint64"]; ok {
+			switch v := intlike.(type) {
+			case int:
+				casted := (uint64)(v)
+				sv.Value = casted
+				return nil
+			default:
+				return fmt.Errorf("invalid intlike type: %T", intlike)
 			}
 		}
 

--- a/tests/destination-data/test-cases/01_softdelete_01/expected.yaml
+++ b/tests/destination-data/test-cases/01_softdelete_01/expected.yaml
@@ -1,0 +1,18 @@
+tables:
+  transaction:
+    - _fivetran_id: txn1
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      amount: 1010.0
+      id:
+        table: transaction
+        id: "txn1"
+    - _fivetran_id: txn4
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      amount: 104.0
+      id:
+        table: transaction
+        id: "txn4"

--- a/tests/destination-data/test-cases/01_softdelete_01/input.json
+++ b/tests/destination-data/test-cases/01_softdelete_01/input.json
@@ -1,0 +1,30 @@
+{
+   "create_table" : {
+      "transaction": {
+         "columns": {
+            "amount" : "DOUBLE"
+         },
+         "history_mode": false
+      }
+   },
+   "describe_table" : [
+      "transaction"
+   ],
+   "ops" : [
+      {
+         "upsert": {
+            "transaction": [
+               {"_fivetran_id":"txn1", "amount": 101},
+               {"_fivetran_id":"txn4", "amount": 104}
+            ]
+         }
+      },
+      {
+         "update": {
+            "transaction": [
+               {"_fivetran_id":"txn1", "amount": 1010}
+            ]
+         }
+      }
+   ]
+}

--- a/tests/destination-data/test-cases/01_softdelete_02/expected.yaml
+++ b/tests/destination-data/test-cases/01_softdelete_02/expected.yaml
@@ -1,0 +1,38 @@
+tables:
+  transaction:
+    - _fivetran_deleted: true
+      _fivetran_id: txn1
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      amount: 1010.0
+      id:
+        table: transaction
+        id: "txn1"
+    - _fivetran_deleted: false
+      _fivetran_id: "txn2"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      amount: 102.0
+      id:
+        table: transaction
+        id: "txn2"
+    - _fivetran_deleted: false
+      amount: 103.0
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      id:
+        table: transaction
+        id: "txn3"
+      _fivetran_id: "txn3"
+    - _fivetran_deleted: true
+      _fivetran_id: txn4
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      amount: 104.0
+      id:
+        table: transaction
+        id: "txn4"

--- a/tests/destination-data/test-cases/01_softdelete_02/input.json
+++ b/tests/destination-data/test-cases/01_softdelete_02/input.json
@@ -1,0 +1,46 @@
+{
+   "create_table" : {
+      "transaction": {
+         "columns": {
+            "amount" : "DOUBLE"
+         },
+         "history_mode": false
+      }
+   },
+   "describe_table" : [
+      "transaction"
+   ],
+   "ops" : [
+      {
+         "upsert": {
+            "transaction": [
+               {"_fivetran_id":"txn1", "amount": 101},
+               {"_fivetran_id":"txn4", "amount": 104}
+            ]
+         }
+      },
+      {
+         "update": {
+            "transaction": [
+               {"_fivetran_id":"txn1", "amount": 1010}
+            ]
+         }
+      },
+      {
+         "upsert": {
+            "transaction": [
+               {"_fivetran_id":"txn2", "amount": 102},
+               {"_fivetran_id":"txn3", "amount": 103}
+            ]
+         }
+      },
+      {
+         "soft_delete": {
+            "transaction": [
+               {"_fivetran_id":"txn1"},
+               {"_fivetran_id":"txn4"}
+            ]
+         }
+      }
+   ]
+}

--- a/tests/destination-data/test-cases/02_history_01/expected.yaml
+++ b/tests/destination-data/test-cases/02_history_01/expected.yaml
@@ -1,0 +1,100 @@
+tables:
+  transaction:
+    - _fivetran_active: false
+      _fivetran_end:
+        time: "2005-05-24T20:57:59Z"
+      _fivetran_start:
+        time: "2005-05-23T20:57:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 1
+      id:
+        table: transaction
+        id: ["1", "2005-05-23T20:57:00Z"]
+      amount: 100.0
+    - _fivetran_active: true
+      _fivetran_end:
+        time: "9999-12-31T23:59:59Z"
+      _fivetran_start:
+        time: "2005-05-24T20:58:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 1
+      id:
+        table: transaction
+        id: ["1", "2005-05-24T20:58:00Z"]
+      amount: 101.0
+    - _fivetran_active: false
+      _fivetran_end:
+        time: "2005-05-24T20:57:59Z"
+      _fivetran_start:
+        time: "2005-05-23T20:57:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 2
+      id:
+        table: transaction
+        id: ["2", "2005-05-23T20:57:00Z"]
+      amount: 200.0
+    - _fivetran_active: true
+      _fivetran_end:
+        time: "9999-12-31T23:59:59Z"
+      _fivetran_start:
+        time: "2005-05-24T20:58:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 2
+      id:
+        table: transaction
+        id: ["2", "2005-05-24T20:58:00Z"]
+      amount: 201.0
+    - _fivetran_active: false
+      _fivetran_end:
+        time: "2005-05-24T20:58:59Z"
+      _fivetran_start:
+        time: "2005-05-23T20:57:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 3
+      id:
+        table: transaction
+        id: ["3", "2005-05-23T20:57:00Z"]
+      amount: 300.0
+    - _fivetran_active: true
+      _fivetran_end:
+        time: "9999-12-31T23:59:59Z"
+      _fivetran_start:
+        time: "2005-05-24T20:59:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 3
+      id:
+        table: transaction
+        id: ["3", "2005-05-24T20:59:00Z"]
+      amount: 301.0
+    - _fivetran_active: true
+      _fivetran_end:
+        time: "9999-12-31T23:59:59Z"
+      _fivetran_start:
+        time: "2005-05-23T20:57:00Z"
+      _fivetran_synced:
+        recent-enough:
+          within: 30s
+      myid:
+        uint64: 4
+      id:
+        table: transaction
+        id: ["4", "2005-05-23T20:57:00Z"]
+      amount: 400.0

--- a/tests/destination-data/test-cases/02_history_01/input.json
+++ b/tests/destination-data/test-cases/02_history_01/input.json
@@ -1,0 +1,52 @@
+{
+   "create_table" : {
+      "transaction": {
+         "columns": {
+            "myid": "INT",
+            "amount" : "DOUBLE"
+         },
+         "primary_key": ["myid"],
+         "history_mode": true
+      }
+   },
+   "alter_table" : {
+      "transaction": {
+         "columns": {
+            "myid": "INT",
+            "amount" : "FLOAT"
+         },
+         "primary_key": ["myid"],
+         "history_mode": true
+      }
+   },
+   "describe_table" : [
+      "transaction"
+   ],
+   "ops" : [
+      {
+         "upsert": {
+            "transaction": [
+               {"myid":1, "amount": 100, "op_time":"2005-05-23T20:57:00Z"},
+               {"myid":2, "amount": 200, "op_time":"2005-05-23T20:57:00Z"},
+               {"myid":3, "amount": 300, "op_time":"2005-05-23T20:57:00Z"},
+               {"myid":4, "amount": 400, "op_time":"2005-05-23T20:57:00Z"}
+            ]
+         }
+      },
+      {
+         "update": {
+            "transaction": [
+               {"myid":1, "amount": 101 ,"op_time":"2005-05-24T20:58:00Z"},
+               {"myid":2, "amount": 201 ,"op_time":"2005-05-24T20:58:00Z"}
+            ]
+         }
+      },
+      {
+         "upsert": {
+            "transaction": [
+               {"myid": 3, "amount": 301, "op_time":"2005-05-24T20:59:00Z"}
+            ]
+         }
+      }
+   ]
+} 


### PR DESCRIPTION
I've addressed the following things to make this connector more feature-complete:

- Added proper support for soft-truncation and soft-deletion for the soft-delete sync mode
- Fixed how you handle compound primary keys. It fixed the history mode, too
- Added the type conversion from SurrealDB object field to Fivetran JSON column