### PR TITLE
Fix DescribeTable not to fail on JSON column

### DIFF
--- a/internal/connector/describe_table_test.go
+++ b/internal/connector/describe_table_test.go
@@ -1,0 +1,104 @@
+package connector
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	pb "github.com/surrealdb/fivetran-destination/internal/pb"
+	"github.com/surrealdb/surrealdb.go"
+)
+
+func TestDescribeTable_all_data_types(t *testing.T) {
+	surrealdbEndpoint := os.Getenv("SURREALDB_ENDPOINT")
+	if surrealdbEndpoint == "" {
+		t.Skip("SURREALDB_ENDPOINT is not set")
+	}
+
+	sdb, err := surrealdb.New(surrealdbEndpoint)
+	if err != nil {
+		t.Fatalf("failed to connect to surrealdb: %v", err)
+	}
+
+	_, err = sdb.SignIn(&surrealdb.Auth{
+		Username: "root",
+		Password: "root",
+	})
+	require.NoError(t, err)
+
+	err = sdb.Use("test", "test")
+	require.NoError(t, err)
+
+	_, err = surrealdb.Query[any](sdb, "REMOVE TABLE IF EXISTS txn1;", nil)
+	require.NoError(t, err)
+
+	srv := NewServer(zerolog.New(os.Stdout).Level(zerolog.DebugLevel))
+	created, err := srv.CreateTable(context.Background(), &pb.CreateTableRequest{
+		Configuration: map[string]string{
+			"url":  surrealdbEndpoint,
+			"ns":   "test",
+			"user": "root",
+			"pass": "root",
+		},
+		SchemaName: "test",
+		Table: &pb.Table{
+			Name: "txn1",
+			Columns: []*pb.Column{
+				{Name: "myid", Type: pb.DataType_STRING},
+				{Name: "mybool", Type: pb.DataType_BOOLEAN},
+				{Name: "myshort", Type: pb.DataType_SHORT},
+				{Name: "myint", Type: pb.DataType_INT},
+				{Name: "mylong", Type: pb.DataType_LONG},
+				{Name: "mydecimal", Type: pb.DataType_DECIMAL},
+				{Name: "myfloat", Type: pb.DataType_FLOAT},
+				{Name: "mydouble", Type: pb.DataType_DOUBLE},
+				{Name: "mynaivedate", Type: pb.DataType_NAIVE_DATE},
+				{Name: "mynaivedatetime", Type: pb.DataType_NAIVE_DATETIME},
+				{Name: "myutcdatetime", Type: pb.DataType_UTC_DATETIME},
+				{Name: "mybinary", Type: pb.DataType_BINARY},
+				{Name: "myxml", Type: pb.DataType_XML},
+				{Name: "mystring", Type: pb.DataType_STRING},
+				{Name: "myjson", Type: pb.DataType_JSON},
+				{Name: "mynaivetime", Type: pb.DataType_NAIVE_TIME},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, &pb.CreateTableResponse_Success{Success: true}, created.Response)
+	described, err := srv.DescribeTable(context.Background(), &pb.DescribeTableRequest{
+		Configuration: map[string]string{
+			"url":  surrealdbEndpoint,
+			"ns":   "test",
+			"user": "root",
+			"pass": "root",
+		},
+		SchemaName: "test",
+		TableName:  "txn1",
+	})
+	require.NoError(t, err)
+	require.Equal(t, &pb.DescribeTableResponse_Table{
+		Table: &pb.Table{
+			Name: "txn1",
+			Columns: []*pb.Column{
+				{Name: "myid", Type: pb.DataType_STRING},
+				{Name: "mybool", Type: pb.DataType_BOOLEAN},
+				{Name: "myshort", Type: pb.DataType_SHORT},
+				{Name: "myint", Type: pb.DataType_INT},
+				{Name: "mylong", Type: pb.DataType_LONG},
+				{Name: "mydecimal", Type: pb.DataType_DECIMAL},
+				{Name: "myfloat", Type: pb.DataType_FLOAT},
+				{Name: "mydouble", Type: pb.DataType_DOUBLE},
+				{Name: "mynaivedate", Type: pb.DataType_NAIVE_DATE},
+				{Name: "mynaivedatetime", Type: pb.DataType_NAIVE_DATETIME},
+				{Name: "myutcdatetime", Type: pb.DataType_UTC_DATETIME},
+				{Name: "mybinary", Type: pb.DataType_BINARY},
+				{Name: "myxml", Type: pb.DataType_XML},
+				{Name: "mystring", Type: pb.DataType_STRING},
+				{Name: "myjson", Type: pb.DataType_JSON},
+				{Name: "mynaivetime", Type: pb.DataType_NAIVE_TIME},
+			},
+		},
+	}, described.Response)
+}

--- a/internal/connector/table_define.go
+++ b/internal/connector/table_define.go
@@ -31,7 +31,7 @@ func (s *Server) defineTable(db *surrealdb.DB, table *pb.Table) error {
 
 	var historyMode bool
 
-	for _, c := range table.Columns {
+	for i, c := range table.Columns {
 		if c.Name == "id" {
 			if s.debugging() {
 				s.logDebug("Skipping id")
@@ -48,7 +48,7 @@ func (s *Server) defineTable(db *surrealdb.DB, table *pb.Table) error {
 		if err := validateColumnName(c.Name); err != nil {
 			return err
 		}
-		q, err := s.defineFieldQueryFromFt(tb, c)
+		q, err := s.defineFieldQueryFromFt(tb, c, i)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Under the hood, this revises the way we map SurrealDB field type from/to Fivetran column data type, so that the original Fivetran data type is not lost when DescribeTable reconstructs Fivetran schema from SurrealDB.