### PR TITLE
Enable the pprof server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ lint:
 clean:
 	rm -rf bin/
 	rm -rf proto/
-	rm -rf internal/pb/ 
+	rm -rf internal/pb/


### PR DESCRIPTION
We will enable the pprof endpoint for potential production profiling.
It can be disabled by specifying the pprof port to zero, if needed.
