### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/go:1.23-bookworm
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV GO111MODULE=on
+ENV GOPATH=/go
+ENV PATH=$GOPATH/bin:$PATH
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "SurrealDB Fivetran Destination Connector",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "latest",
+      "dockerDashComposeVersion": "v2"
+    }
+  },
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "golang.go"
+      ],
+      "settings": {
+        "go.toolsManagement.checkForUpdates": "local",
+        "go.useLanguageServer": true,
+        "go.gopath": "/go"
+      }
+    }
+  },
+  "postCreateCommand": "go mod download",
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.8'
+
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    command: sleep infinity
+    network_mode: service:surrealdb
+    environment:
+      # This can be "localhost" instead of "surrealdb" because
+      # we are in the `service` network mode.
+      - SURREALDB_HOST=localhost
+      - SURREALDB_PORT=8001
+
+  surrealdb:
+    image: surrealdb/surrealdb:latest
+    command: start --user root --pass root --bind 127.0.0.1:8001
+    ports:
+      # This cannot be "8001:8000" combined with "--bind localhost:8000" because this container is bound
+      # to the devcontainer using service network mode.
+      # In service network mode, the "host" of this "hostport:localport" expression
+      # does not refer to the devcontainer, but the host machine as similar to
+      # other network modes.
+      - "8001:8001"
+    volumes:
+      - surrealdb-data:/data
+    environment:
+      - SURREAL_LOG=trace
+
+volumes:
+  surrealdb-data:


### PR DESCRIPTION
Let's add the devcontainer configuration for developing the connector!
I wanted to add this sooner, but as you know, we need to set up a local SurrealDB instance listening on port 8001 to run the tests added in #11, so it's time to do so.
With the devcontainer, you do not need to set up anything to make tests pass locally, which would greatly help us contribute to this project.