### PR TITLE
e2e: Fix tester WORKING_DIR on GitHub Actions

### DIFF
--- a/tests/destination-connector-test.sh
+++ b/tests/destination-connector-test.sh
@@ -323,7 +323,7 @@ run_test_case() {
     docker run --mount type=bind,source="$(pwd)/destination-data",target=/data \
       -a STDIN -a STDOUT -a STDERR $DOCKER_TTY_FLAG \
       $DOCKER_LINK_ARG \
-      -e WORKING_DIR="$(pwd)/destination-data" \
+      -e WORKING_DIR="/data" \
       -e GRPC_HOSTNAME=$GRPC_HOSTNAME \
       us-docker.pkg.dev/build-286712/public-docker-us/sdktesters-v2/sdk-tester:$SDK_TESTER_TAG \
       --tester-type destination --port 50052 --input-file "input_${case_name}.json" \


### PR DESCRIPTION
Fixes the following error we are seeing on GHA:

```
Jul 09, 2025 07:29:15 AM: WARNING Fivetran-Tester-Process: Replacing definition for table: transaction 
Jul 09, 2025 07:29:15 AM: INFO Fivetran-Tester-Process: Create Table succeeded: transaction 
Jul 09, 2025 07:29:15 AM: INFO Fivetran-Tester-Process: Create Table succeeded: campaign 
Jul 09, 2025 07:29:15 AM: INFO Fivetran-Tester-Process: Updating definition for table: transaction 
Jul 09, 2025 07:29:15 AM: INFO Fivetran-Tester-Process: Alter Table succeeded: transaction 
Jul 09, 2025 07:29:16 AM: SEVERE Fivetran-Tester-Process: Sync FAILEDio.grpc.StatusRuntimeException: UNKNOWN: failed to open fivetran file: failed to create fivetran file reader: failed to open file: open /home/runner/work/fivetran-destination/fivetran-destination/tests/destination-data/campaign_input_case2_upsert.csv.zstd.aes: no such file or directory 
Exception in thread "main" io.grpc.StatusRuntimeException: UNKNOWN: failed to open fivetran file: failed to create fivetran file reader: failed to open file: open /home/runner/work/fivetran-destination/fivetran-destination/tests/destination-data/campaign_input_case2_upsert.csv.zstd.aes: no such file or directory
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:351)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:332)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:174)
	at fivetran_sdk.v2.DestinationConnectorGrpc$DestinationConnectorBlockingStub.writeBatch(DestinationConnectorGrpc.java:672)
	at com.fivetran.fivetran_sdk.v2.client.destination.SdkWriterClient.writeBatch(SdkWriterClient.java:183)
	at com.fivetran.fivetran_sdk.v2.tools.testers.SdkDestinationTester.lambda$executeInputFile$4(SdkDestinationTester.java:372)
	at com.fivetran.fivetran_sdk.v2.tools.testers.util.SdkUtils.executeWithErrorHandling(SdkUtils.java:23)
	at com.fivetran.fivetran_sdk.v2.tools.testers.util.SdkUtils.executeWithErrorHandling(SdkUtils.java:18)
	at com.fivetran.fivetran_sdk.v2.tools.testers.SdkDestinationTester.executeInputFile(SdkDestinationTester.java:370)
	at com.fivetran.fivetran_sdk.v2.tools.testers.SdkDestinationTester.run(SdkDestinationTester.java:131)
	at com.fivetran.fivetran_sdk.v2.tools.testers.SdkDestinationTester.start(SdkDestinationTester.java:64)
	at com.fivetran.fivetran_sdk.v2.tools.testers.SdkTester.main(SdkTester.java:105)
```

https://github.com/surrealdb/fivetran-destination/actions/runs/16163043921