### PR TITLE
Change CI workflow trigger from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,7 +1,7 @@
 name: PR Tests
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [ main ]
   push:
     branches: [ main ]


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The workflow is now triggered by `pull_request` events instead of `pull_request_target` events.